### PR TITLE
feat: remove input vars from cli

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -45,7 +45,7 @@ runs:
     - run: poetry install -C ${{ inputs.pyproject_path }} --with ${{ inputs.workflow }}
       working-directory: ${{ inputs.working_directory }}
       shell: bash
-     
+
     - id: run-dagger
       run: poetry -C ${{ inputs.pyproject_path }} run firestarter ${{ inputs.workflow }}
       working-directory: ${{ inputs.working_directory }}

--- a/action.yaml
+++ b/action.yaml
@@ -45,8 +45,8 @@ runs:
     - run: poetry install -C ${{ inputs.pyproject_path }} --with ${{ inputs.workflow }}
       working-directory: ${{ inputs.working_directory }}
       shell: bash
-
+     
     - id: run-dagger
-      run: poetry -C ${{ inputs.pyproject_path }} run firestarter ${{ inputs.workflow }} --config_file ${{ inputs.config_file }} --secrets='${{ inputs.secrets }}' --vars='${{ inputs.vars }}'
+      run: poetry -C ${{ inputs.pyproject_path }} run firestarter ${{ inputs.workflow }}
       working-directory: ${{ inputs.working_directory }}
       shell: bash


### PR DESCRIPTION
They come from the environment, see [actions-toolkit](https://github.com/actions/toolkit/blob/457303960f03375db6f033e214b9f90d79c3fe5c/packages/core/src/core.ts#L126-L138
)

```js
    process.env[`INPUT_${name.replace(/ /g, '_').toUpperCase()}`] || ''
```

